### PR TITLE
OPENEUROPA-2037: Implement new config setting for value check.

### DIFF
--- a/modules/entity_version_workflows/config/schema/entity_version_workflows.schema.yml
+++ b/modules/entity_version_workflows/config/schema/entity_version_workflows.schema.yml
@@ -16,3 +16,6 @@ workflows.workflow.*.third_party.entity_version_workflows:
       patch:
         type: string
         label: 'Patch action'
+      check_values_changed:
+        type: boolean
+        label: 'Check values changed'

--- a/modules/entity_version_workflows/entity_version_workflows.module
+++ b/modules/entity_version_workflows/entity_version_workflows.module
@@ -52,7 +52,7 @@ function _entity_version_workflows_alter_transition_forms(&$form, FormStateInter
     $form['version'][$version] = [
       '#type' => 'select',
       '#title' => $label,
-      '#default_value' => $values ? $values[$version] : '',
+      '#default_value' => empty($values[$version]) ? '' : $values[$version],
       '#options' => [
         '' => t('Nothing'),
         'increase' => t('Increase'),
@@ -61,8 +61,15 @@ function _entity_version_workflows_alter_transition_forms(&$form, FormStateInter
       ],
       '#required' => FALSE,
     ];
-
   }
+
+  $form['version']['check_values_changed'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Check values changed'),
+    '#description' => t('Apply the rules above only if the entity has changed during the transition.'),
+    '#default_value' => empty($values['check_values_changed']) ? 0 : $values['check_values_changed'],
+    '#required' => FALSE,
+  ];
 
   $form['#entity_builders'][] = 'entity_version_workflows_form_transition_add_form_builder';
 }
@@ -80,14 +87,15 @@ function _entity_version_workflows_alter_transition_forms(&$form, FormStateInter
  *   The form state object.
  */
 function entity_version_workflows_form_transition_add_form_builder($entity_type, WorkflowInterface $workflow, &$form, FormStateInterface $form_state): void {
-  $version_fields = [
+  $config_fields = [
     'major',
     'minor',
     'patch',
+    'check_values_changed',
   ];
   $values = [];
 
-  foreach ($version_fields as $field) {
+  foreach ($config_fields as $field) {
     if ($form_state->getValue($field)) {
       $values[$field] = $form_state->getValue($field);
     }

--- a/modules/entity_version_workflows/entity_version_workflows.module
+++ b/modules/entity_version_workflows/entity_version_workflows.module
@@ -66,7 +66,7 @@ function _entity_version_workflows_alter_transition_forms(&$form, FormStateInter
   $form['version']['check_values_changed'] = [
     '#type' => 'checkbox',
     '#title' => t('Check values changed'),
-    '#description' => t('Apply the rules above only if the entity has changed during the transition.'),
+    '#description' => t('Apply the rules above only if the entity field values have changed during the transition.'),
     '#default_value' => empty($values['check_values_changed']) ? 0 : $values['check_values_changed'],
     '#required' => FALSE,
   ];

--- a/modules/entity_version_workflows/entity_version_workflows.services.yml
+++ b/modules/entity_version_workflows/entity_version_workflows.services.yml
@@ -1,4 +1,4 @@
 services:
   entity_version_workflows.entity_version_workflow_manager:
     class: Drupal\entity_version_workflows\EntityVersionWorkflowManager
-    arguments: ['@content_moderation.moderation_information', '@entity_type.manager', '@module_handler', '@event_dispatcher']
+    arguments: ['@content_moderation.moderation_information', '@entity_type.manager', '@event_dispatcher']

--- a/modules/entity_version_workflows/entity_version_workflows.services.yml
+++ b/modules/entity_version_workflows/entity_version_workflows.services.yml
@@ -1,4 +1,4 @@
 services:
   entity_version_workflows.entity_version_workflow_manager:
     class: Drupal\entity_version_workflows\EntityVersionWorkflowManager
-    arguments: ['@content_moderation.moderation_information', '@entity_type.manager', '@module_handler']
+    arguments: ['@content_moderation.moderation_information', '@entity_type.manager', '@module_handler', '@event_dispatcher']

--- a/modules/entity_version_workflows/entity_version_workflows.services.yml
+++ b/modules/entity_version_workflows/entity_version_workflows.services.yml
@@ -1,4 +1,4 @@
 services:
   entity_version_workflows.entity_version_workflow_manager:
     class: Drupal\entity_version_workflows\EntityVersionWorkflowManager
-    arguments: ['@content_moderation.moderation_information', '@entity_type.manager']
+    arguments: ['@content_moderation.moderation_information', '@entity_type.manager', '@module_handler']

--- a/modules/entity_version_workflows/modules/entity_version_workflows_example/config/install/workflows.workflow.example_workflow.yml
+++ b/modules/entity_version_workflows/modules/entity_version_workflows_example/config/install/workflows.workflow.example_workflow.yml
@@ -10,6 +10,7 @@ third_party_settings:
   entity_version_workflows:
     create_new_draft:
       patch: increase
+      check_values_changed: true
     validate:
       minor: increase
       patch: reset

--- a/modules/entity_version_workflows/modules/entity_version_workflows_example/entity_version_workflows_example.services.yml
+++ b/modules/entity_version_workflows/modules/entity_version_workflows_example/entity_version_workflows_example.services.yml
@@ -1,0 +1,6 @@
+services:
+  entity_version_workflows_example.event_subscriber.test_check_entity_changes:
+    arguments: ['@state']
+    class: Drupal\entity_version_workflows_example\EventSubscriber\TestCheckEntityChangedSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/modules/entity_version_workflows/modules/entity_version_workflows_example/src/EventSubscriber/TestCheckEntityChangedSubscriber.php
+++ b/modules/entity_version_workflows/modules/entity_version_workflows_example/src/EventSubscriber/TestCheckEntityChangedSubscriber.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\entity_version_workflows_example\EventSubscriber;
+
+use Drupal\Core\State\State;
+use Drupal\entity_version_workflows\Event\CheckEntityChangedEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Test event subscriber for the entity changed blacklisted fields.
+ */
+class TestCheckEntityChangedSubscriber implements EventSubscriberInterface {
+
+  const STATE = 'entity_version.test_skip_title_on';
+
+  /**
+   * The state.
+   *
+   * @var \Drupal\Core\State\State
+   */
+  protected $state;
+
+  /**
+   * TestCheckEntityChangedSubscriber constructor.
+   *
+   * @param \Drupal\Core\State\State $state
+   *   The state.
+   */
+  public function __construct(State $state) {
+    $this->state = $state;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      CheckEntityChangedEvent::EVENT => 'skipTitle',
+    ];
+  }
+
+  /**
+   * Skips the node title from when checking for entity changes.
+   *
+   * @param \Drupal\entity_version_workflows\Event\CheckEntityChangedEvent $event
+   *   The event.
+   */
+  public function skipTitle(CheckEntityChangedEvent $event): void {
+    if ($this->state->get(static::STATE) !== TRUE) {
+      return;
+    }
+
+    $field_blacklist = $event->getFieldBlacklist();
+    $field_blacklist[] = 'title';
+    $event->setFieldBlacklist($field_blacklist);
+  }
+
+}

--- a/modules/entity_version_workflows/src/EntityVersionWorkflowManager.php
+++ b/modules/entity_version_workflows/src/EntityVersionWorkflowManager.php
@@ -6,6 +6,7 @@ namespace Drupal\entity_version_workflows;
 
 use Drupal\content_moderation\ModerationInformationInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityChangesDetectionTrait;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\entity_version_workflows\Event\CheckEntityChangedEvent;
 use InvalidArgumentException;
@@ -15,6 +16,10 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * Handler to control the entity version numbers for when workflows are used.
  */
 class EntityVersionWorkflowManager {
+
+  use EntityChangesDetectionTrait {
+    getFieldsToSkipFromTranslationChangesCheck as getFieldsToSkipFromEntityChangesCheck;
+  }
 
   /**
    * The symfony event dispatcher.
@@ -133,11 +138,7 @@ class EntityVersionWorkflowManager {
     $fields = array_keys($entity->toArray());
 
     // Blacklist dynamic fields from the check and allow subscribers to change.
-    $field_blacklist = [
-      'vid',
-      'revision_timestamp',
-      'moderation_state',
-    ];
+    $field_blacklist = $this->getFieldsToSkipFromEntityChangesCheck($entity);
     $event = new CheckEntityChangedEvent();
     $event->setFieldBlacklist($field_blacklist);
     $this->eventDispatcher->dispatch(CheckEntityChangedEvent::EVENT, $event);

--- a/modules/entity_version_workflows/src/EntityVersionWorkflowManager.php
+++ b/modules/entity_version_workflows/src/EntityVersionWorkflowManager.php
@@ -7,6 +7,8 @@ namespace Drupal\entity_version_workflows;
 use Drupal\content_moderation\ModerationInformationInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use InvalidArgumentException;
 
 /**
  * Handler to control the entity version numbers for when workflows are used.
@@ -28,16 +30,26 @@ class EntityVersionWorkflowManager {
   protected $entityTypeManager;
 
   /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
    * Constructs a new EntityVersionWorkflowHandler.
    *
    * @param \Drupal\content_moderation\ModerationInformationInterface $moderation_info
    *   The moderation information service.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   The entity type manager.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler
+   *   The module handler.
    */
-  public function __construct(ModerationInformationInterface $moderation_info, EntityTypeManagerInterface $entityTypeManager) {
+  public function __construct(ModerationInformationInterface $moderation_info, EntityTypeManagerInterface $entityTypeManager, ModuleHandlerInterface $moduleHandler) {
     $this->moderationInfo = $moderation_info;
     $this->entityTypeManager = $entityTypeManager;
+    $this->moduleHandler = $moduleHandler;
   }
 
   /**
@@ -71,19 +83,73 @@ class EntityVersionWorkflowManager {
     // from the transition.
     $current_state = $revision->moderation_state->value;
     $next_state = $entity->moderation_state->value;
-    /** @var \Drupal\workflows\TransitionInterface $transition */
-    $transition = $workflow_plugin->getTransitionFromStateToState($current_state, $next_state);
-    $values = $workflow->getThirdPartySetting('entity_version_workflows', $transition->id());
-    if (!$values) {
+
+    // Try to get the transition or do nothing.
+    try {
+      /** @var \Drupal\workflows\TransitionInterface $transition */
+      $transition = $workflow_plugin->getTransitionFromStateToState($current_state, $next_state);
+    }
+    catch (InvalidArgumentException $e) {
       return;
     }
 
+    $config_values = $workflow->getThirdPartySetting('entity_version_workflows', $transition->id());
+    if (!$config_values) {
+      return;
+    }
+
+    // If the config is set to "1" we check if the entity values has changed
+    // and then update the version numbers.
+    if (!empty($config_values['check_values_changed'])) {
+      if (!$this->isEntityChanged($entity)) {
+        return;
+      }
+      // Remove this to leave the version settings only for the iteration.
+      unset($config_values['check_values_changed']);
+    }
+
     // Execute all the configured actions on all the values of the field.
-    foreach ($values as $version => $action) {
+    foreach ($config_values as $version => $action) {
       foreach ($entity->get($field_name)->getValue() as $delta => $value) {
         $entity->get($field_name)->get($delta)->$action($version);
       }
     }
+  }
+
+  /**
+   * Check if the entity has changed.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The content entity object.
+   *
+   * @return bool
+   *   Return true if the entity has changed, otherwise return false.
+   */
+  protected function isEntityChanged(ContentEntityInterface $entity): bool {
+    if (empty($entity->original)) {
+      return FALSE;
+    }
+    $fields = array_keys($entity->toArray());
+    // Blacklist dynamic fields from the check.
+    $field_blacklist = [
+      'vid',
+      'revision_timestamp',
+      'moderation_state',
+    ];
+
+    // Let others change the blacklist.
+    $this->moduleHandler->alter('check_values_changed', $field_blacklist);
+
+    // Remove the blacklisted fields from checking.
+    $fields = array_diff($fields, $field_blacklist);
+    foreach ($fields as $field) {
+      // Check if the values are changed in the entity.
+      if ($entity->get($field)->hasAffectingChanges($entity->original->get($field)->filterEmptyItems(), $entity->language()->getId())) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
   }
 
 }

--- a/modules/entity_version_workflows/src/EntityVersionWorkflowManager.php
+++ b/modules/entity_version_workflows/src/EntityVersionWorkflowManager.php
@@ -98,8 +98,8 @@ class EntityVersionWorkflowManager {
       return;
     }
 
-    // If the config is set to "1" we check if the entity values has changed
-    // and then update the version numbers.
+    // If the config is defined to check entity field values changes we don't
+    // act if they did not change.
     if (!empty($config_values['check_values_changed'])) {
       if (!$this->isEntityChanged($entity)) {
         return;

--- a/modules/entity_version_workflows/src/EntityVersionWorkflowManager.php
+++ b/modules/entity_version_workflows/src/EntityVersionWorkflowManager.php
@@ -139,12 +139,13 @@ class EntityVersionWorkflowManager {
 
     // Let others change the blacklist.
     $this->moduleHandler->alter('check_values_changed', $field_blacklist);
-
+    // We consider the latest revision as original to compare with the entity.
+    $original = $revision = $this->moderationInfo->getLatestRevision($entity->getEntityTypeId(), $entity->id());
     // Remove the blacklisted fields from checking.
     $fields = array_diff($fields, $field_blacklist);
     foreach ($fields as $field) {
       // Check if the values are changed in the entity.
-      if ($entity->get($field)->hasAffectingChanges($entity->original->get($field)->filterEmptyItems(), $entity->language()->getId())) {
+      if ($entity->get($field)->hasAffectingChanges($original->get($field)->filterEmptyItems(), $entity->language()->getId())) {
         return TRUE;
       }
     }

--- a/modules/entity_version_workflows/src/Event/CheckEntityChangedEvent.php
+++ b/modules/entity_version_workflows/src/Event/CheckEntityChangedEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\entity_version_workflows\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event class to be dispatched from EntityVersionWorkflowManager service.
+ */
+class CheckEntityChangedEvent extends Event {
+
+  const EVENT = 'entity_version_worfklows.check_entity_changed_event';
+
+  /**
+   * The array of field names to exclude from change check.
+   *
+   * @var array
+   */
+  protected $field_blacklist;
+
+  /**
+   * @return array
+   */
+  public function getFieldBlacklist() {
+    return $this->field_blacklist;
+  }
+
+  /**
+   * @param array $field_blacklist
+   */
+  public function setFieldBlacklist($field_blacklist) {
+    $this->field_blacklist = $field_blacklist;
+  }
+
+}

--- a/modules/entity_version_workflows/src/Event/CheckEntityChangedEvent.php
+++ b/modules/entity_version_workflows/src/Event/CheckEntityChangedEvent.php
@@ -18,20 +18,26 @@ class CheckEntityChangedEvent extends Event {
    *
    * @var array
    */
-  protected $field_blacklist;
+  protected $fieldBlacklist;
 
   /**
+   * Get the array of blacklisted fields.
+   *
    * @return array
+   *   Return the array of blacklisted fields.
    */
   public function getFieldBlacklist() {
-    return $this->field_blacklist;
+    return $this->fieldBlacklist;
   }
 
   /**
+   * Set the black listed fields.
+   *
    * @param array $field_blacklist
+   *   The black listed field names.
    */
-  public function setFieldBlacklist($field_blacklist) {
-    $this->field_blacklist = $field_blacklist;
+  public function setFieldBlacklist(array $field_blacklist) {
+    $this->fieldBlacklist = $field_blacklist;
   }
 
 }

--- a/modules/entity_version_workflows/src/Event/CheckEntityChangedEvent.php
+++ b/modules/entity_version_workflows/src/Event/CheckEntityChangedEvent.php
@@ -7,14 +7,17 @@ namespace Drupal\entity_version_workflows\Event;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
- * Event class to be dispatched from EntityVersionWorkflowManager service.
+ * Dispatched by EntityVersionWorkflowManager::isEntityChanged().
+ *
+ * Allows to alter the list of fields that should be skipped when checking an
+ * entity for value changes.
  */
 class CheckEntityChangedEvent extends Event {
 
   const EVENT = 'entity_version_worfklows.check_entity_changed_event';
 
   /**
-   * The array of field names to exclude from change check.
+   * The array of field names to skip.
    *
    * @var array
    */
@@ -26,7 +29,7 @@ class CheckEntityChangedEvent extends Event {
    * @return array
    *   Return the array of blacklisted fields.
    */
-  public function getFieldBlacklist() {
+  public function getFieldBlacklist(): array {
     return $this->fieldBlacklist;
   }
 
@@ -36,7 +39,7 @@ class CheckEntityChangedEvent extends Event {
    * @param array $field_blacklist
    *   The black listed field names.
    */
-  public function setFieldBlacklist(array $field_blacklist) {
+  public function setFieldBlacklist(array $field_blacklist): void {
     $this->fieldBlacklist = $field_blacklist;
   }
 

--- a/modules/entity_version_workflows/tests/Functional/EntityVersionWorkflowsConfigUITest.php
+++ b/modules/entity_version_workflows/tests/Functional/EntityVersionWorkflowsConfigUITest.php
@@ -80,6 +80,8 @@ class EntityVersionWorkflowsConfigUITest extends BrowserTestBase {
     $this->assertSession()->optionExists('Patch', 'decrease');
     $this->assertSession()->optionExists('Patch', 'reset');
 
+    $this->assertSession()->checkboxNotChecked('Check values changed');
+
     // Assert that we have no third party settings from our module on the
     // created workflow.
     $workflow = Workflow::load('content_moderation');
@@ -90,6 +92,7 @@ class EntityVersionWorkflowsConfigUITest extends BrowserTestBase {
     $this->getSession()->getPage()->selectFieldOption('Major', 'increase');
     $this->getSession()->getPage()->selectFieldOption('Minor', 'decrease');
     $this->getSession()->getPage()->selectFieldOption('Patch', 'reset');
+    $this->getSession()->getPage()->checkField('Check values changed');
     $this->getSession()->getPage()->pressButton('Save');
 
     // Check that the third party settings have been saved correctly.
@@ -98,6 +101,7 @@ class EntityVersionWorkflowsConfigUITest extends BrowserTestBase {
       'major' => 'increase',
       'minor' => 'decrease',
       'patch' => 'reset',
+      'check_values_changed' => 1,
     ];
     $this->assertEquals($expected, $workflow->getThirdPartySetting('entity_version_workflows', 'create_new_draft'));
   }

--- a/modules/entity_version_workflows/tests/Kernel/EntityVersionWorkflowsTest.php
+++ b/modules/entity_version_workflows/tests/Kernel/EntityVersionWorkflowsTest.php
@@ -105,7 +105,13 @@ class EntityVersionWorkflowsTest extends KernelTestBase {
     $node->set('moderation_state', 'draft');
     $node->save();
     $this->assertNodeVersion($node, 1, 0, 1);
+    // We change value so the version will change.
     $node->set('title', 'New title 3');
+    $node->save();
+    $this->assertNodeVersion($node, 1, 0, 2);
+    // Check if values are not changed no version is changed.
+    $node->save();
+    $this->assertNodeVersion($node, 1, 0, 2);
     $node->save();
     $this->assertNodeVersion($node, 1, 0, 2);
 
@@ -113,9 +119,10 @@ class EntityVersionWorkflowsTest extends KernelTestBase {
     $node->set('moderation_state', 'validated');
     $node->save();
     $this->assertNodeVersion($node, 1, 1, 0);
+    // Move back to draft without changing the value and version.
     $node->set('moderation_state', 'draft');
     $node->save();
-    $this->assertNodeVersion($node, 1, 1, 1);
+    $this->assertNodeVersion($node, 1, 1, 0);
   }
 
   /**

--- a/modules/entity_version_workflows/tests/Kernel/EntityVersionWorkflowsTest.php
+++ b/modules/entity_version_workflows/tests/Kernel/EntityVersionWorkflowsTest.php
@@ -72,10 +72,12 @@ class EntityVersionWorkflowsTest extends KernelTestBase {
     $this->assertNodeVersion($node, 0, 0, 0);
 
     // Save to increase the patch number (stay in draft).
+    $node->set('title', 'New title');
     $node->save();
     $this->assertNodeVersion($node, 0, 0, 1);
     $node->save();
-    $this->assertNodeVersion($node, 0, 0, 2);
+    // Since Check values changed is enabled the version remains the same.
+    $this->assertNodeVersion($node, 0, 0, 1);
 
     // Validate the content to increase the minor and reset the patch.
     $node->set('moderation_state', 'validated');
@@ -84,8 +86,10 @@ class EntityVersionWorkflowsTest extends KernelTestBase {
 
     // Make a new draft to increase patch on the new minor.
     $node->set('moderation_state', 'draft');
+    $node->set('title', 'New title 1');
     $node->save();
     $this->assertNodeVersion($node, 0, 1, 1);
+    $node->set('title', 'New title 2');
     $node->save();
     $this->assertNodeVersion($node, 0, 1, 2);
 
@@ -101,6 +105,7 @@ class EntityVersionWorkflowsTest extends KernelTestBase {
     $node->set('moderation_state', 'draft');
     $node->save();
     $this->assertNodeVersion($node, 1, 0, 1);
+    $node->set('title', 'New title 3');
     $node->save();
     $this->assertNodeVersion($node, 1, 0, 2);
 


### PR DESCRIPTION
Implemented a new configuration option for the entity version number behavior on transitions.
The new config can restrict to apply the configured rules only when the entity has hanged.